### PR TITLE
feat: home page assets section

### DIFF
--- a/site/src/components/home/sections/assets.js
+++ b/site/src/components/home/sections/assets.js
@@ -1,0 +1,69 @@
+import { toPrecision } from "@osn/common";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  assetFetchList,
+  assetListLoadingSelector,
+  assetListSelector,
+} from "../../../store/reducers/assetSlice";
+import { assetsHead } from "../../../utils/constants";
+import AddressOrIdentity from "../../address";
+import ValueDisplay from "../../displayValue";
+import { Flex } from "../../styled/flex";
+import { ColoredInterLink } from "../../styled/link";
+import Symbol from "../../symbol";
+import SymbolName from "../../symbol/name";
+import Table from "../../table";
+import Tooltip from "../../tooltip";
+
+const page = 0;
+const pageSize = 4;
+
+export default function Assets() {
+  const dispatch = useDispatch();
+
+  const assets = useSelector(assetListSelector);
+  const loading = useSelector(assetListLoadingSelector);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    dispatch(
+      assetFetchList(page, pageSize, null, {
+        signal: controller.signal,
+      }),
+    );
+
+    return () => controller.abort();
+  }, [dispatch]);
+
+  const data =
+    assets?.items?.map((asset) => {
+      return [
+        <ColoredInterLink to={`/asset/${asset.assetId}_${asset.assetHeight}`}>
+          #{asset.assetId}
+        </ColoredInterLink>,
+        asset?.metadata?.symbol ? (
+          <Flex gap={8}>
+            <Symbol detail={asset?.detail} symbol={asset.metadata.symbol} />
+            <SymbolName name={asset.metadata.name} />
+          </Flex>
+        ) : (
+          "--"
+        ),
+        <Tooltip tip={asset?.detail?.owner}>
+          <AddressOrIdentity address={asset?.detail?.owner} />
+        </Tooltip>,
+        <Tooltip tip={asset?.detail?.issuer}>
+          <AddressOrIdentity address={asset?.detail?.issuer} />
+        </Tooltip>,
+        asset?.detail?.accounts,
+        <ValueDisplay
+          value={toPrecision(asset?.detail?.supply, asset?.metadata?.decimals)}
+          symbol={asset.symbol}
+        />,
+      ];
+    }) ?? null;
+
+  return <Table heads={assetsHead} data={data} loading={loading} />;
+}

--- a/site/src/components/home/sections/index.js
+++ b/site/src/components/home/sections/index.js
@@ -1,10 +1,10 @@
-import { FlexBetween, FlexEnd } from "../../styled/flex";
+import { FlexBetween, FlexColumn, FlexEnd } from "../../styled/flex";
 import LatestBlocks from "./latestBlocks";
 import React from "react";
 import styled, { css } from "styled-components";
 import { Inter_14_500, Inter_18_700 } from "../../../styles/text";
 import Link from "../../styled/link";
-import { Panel } from "../../styled/panel";
+import { Panel, StyledPanelTableWrapper } from "../../styled/panel";
 import { useSelector } from "react-redux";
 import {
   latestBlocksSelector,
@@ -13,6 +13,7 @@ import {
 import LatestTransfers from "./latestTransfers";
 import { mobilecss } from "../../../styles/responsive";
 import { mdcss } from "../../../styles/responsive";
+import Assets from "./assets";
 
 const Title = styled.h2`
   ${Inter_18_700};
@@ -62,26 +63,38 @@ export default function Sections() {
   const transfers = useSelector(latestSignedTransfersSelector);
 
   return (
-    <SectionsWrapper gap={24}>
-      <Section>
-        <Title>Latest Blocks</Title>
-        <StyledPanel>
-          <LatestBlocks blocks={blocks} />
-          <AnchorWrapper>
-            <Anchor to={"/blocks"}>View All</Anchor>
-          </AnchorWrapper>
-        </StyledPanel>
-      </Section>
+    <FlexColumn gap={32}>
+      <SectionsWrapper gap={24}>
+        <Section>
+          <Title>Latest Blocks</Title>
+          <StyledPanel>
+            <LatestBlocks blocks={blocks} />
+            <AnchorWrapper>
+              <Anchor to={"/blocks"}>View All</Anchor>
+            </AnchorWrapper>
+          </StyledPanel>
+        </Section>
+
+        <Section>
+          <Title>Signed Transfers</Title>
+          <StyledPanel>
+            <LatestTransfers transfers={transfers} />
+            <AnchorWrapper>
+              <Anchor to={"/transfers"}>View All</Anchor>
+            </AnchorWrapper>
+          </StyledPanel>
+        </Section>
+      </SectionsWrapper>
 
       <Section>
-        <Title>Signed Transfers</Title>
-        <StyledPanel>
-          <LatestTransfers transfers={transfers} />
+        <Title>Assets</Title>
+        <StyledPanelTableWrapper>
+          <Assets />
           <AnchorWrapper>
-            <Anchor to={"/transfers"}>View All</Anchor>
+            <Anchor to="/assets">View All</Anchor>
           </AnchorWrapper>
-        </StyledPanel>
+        </StyledPanelTableWrapper>
       </Section>
-    </SectionsWrapper>
+    </FlexColumn>
   );
 }

--- a/site/src/components/styled/flex.js
+++ b/site/src/components/styled/flex.js
@@ -17,3 +17,8 @@ export const FlexBetween = styled(Flex)`
 export const FlexEnd = styled(Flex)`
   justify-content: end;
 `;
+
+export const FlexColumn = styled(Flex)`
+  align-items: unset;
+  flex-direction: column;
+`;

--- a/site/src/components/symbol/index.js
+++ b/site/src/components/symbol/index.js
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+import { Inter_14_600 } from "../../styles/text";
+
+const Wrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Icon = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+const Name = styled.span`
+  color: ${(p) => p.theme.fontPrimary};
+  ${Inter_14_600};
+`;
+
+export default function Symbol({ symbol, detail }) {
+  return (
+    <Wrapper>
+      <Icon src={detail?.icon ?? "/imgs/icons/default.svg"} alt="logo" />
+      <Name>{symbol}</Name>
+    </Wrapper>
+  );
+}

--- a/site/src/components/symbol/name.js
+++ b/site/src/components/symbol/name.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+import { Inter_14_500 } from "../../styles/text";
+
+const Name = styled.span`
+  color: ${(p) => p.theme.fontTertiary};
+  ${Inter_14_500};
+`;
+
+export default function SymbolName({ name }) {
+  return <Name title={name}>{name}</Name>;
+}

--- a/site/src/pages/assets.js
+++ b/site/src/pages/assets.js
@@ -19,6 +19,9 @@ import {
 } from "../store/reducers/assetSlice";
 import { ColoredInterLink } from "../components/styled/link";
 import Tooltip from "../components/tooltip";
+import { Flex } from "../components/styled/flex";
+import SymbolName from "../components/symbol/name";
+import Symbol from "../components/symbol";
 
 function Assets() {
   const location = useLocation();
@@ -51,7 +54,14 @@ function Assets() {
         <ColoredInterLink to={`/asset/${asset.assetId}_${asset.assetHeight}`}>
           #{asset.assetId}
         </ColoredInterLink>,
-        asset?.metadata?.symbol ?? "--",
+        asset?.metadata?.symbol ? (
+          <Flex gap={8}>
+            <Symbol detail={asset?.detail} symbol={asset.metadata.symbol} />
+            <SymbolName name={asset.metadata.name} />
+          </Flex>
+        ) : (
+          "--"
+        ),
         <Tooltip tip={asset?.detail?.owner}>
           <AddressOrIdentity address={asset?.detail?.owner} />
         </Tooltip>,

--- a/site/src/pages/assets.js
+++ b/site/src/pages/assets.js
@@ -58,7 +58,6 @@ function Assets() {
         <Tooltip tip={asset?.detail?.issuer}>
           <AddressOrIdentity address={asset?.detail?.issuer} />
         </Tooltip>,
-        "-",
         asset?.detail?.accounts,
         <ValueDisplay
           value={toPrecision(asset?.detail?.supply, asset?.metadata?.decimals)}

--- a/site/src/utils/constants.js
+++ b/site/src/utils/constants.js
@@ -184,7 +184,6 @@ export const assetsHead = [
   { name: "Symbol", width: 224 },
   { name: "Owner", width: 200 },
   { name: "Issue", width: 200 },
-  { name: "Price", width: 160, align: "center" },
   { name: "Holders", width: 160, align: "center" },
   { name: "Total Supply", width: 200, align: "right" },
 ];

--- a/site/src/utils/constants.js
+++ b/site/src/utils/constants.js
@@ -184,7 +184,7 @@ export const assetsHead = [
   { name: "Symbol", width: 224 },
   { name: "Owner", width: 200 },
   { name: "Issuer", width: 200 },
-  { name: "Holders", width: 160, align: "center" },
+  { name: "Holders", width: 160, align: "right" },
   { name: "Total Supply", width: 200, align: "right" },
 ];
 

--- a/site/src/utils/constants.js
+++ b/site/src/utils/constants.js
@@ -183,7 +183,7 @@ export const assetsHead = [
   { name: "Asset ID", width: 160 },
   { name: "Symbol", width: 224 },
   { name: "Owner", width: 200 },
-  { name: "Issue", width: 200 },
+  { name: "Issuer", width: 200 },
   { name: "Holders", width: 160, align: "center" },
   { name: "Total Supply", width: 200, align: "right" },
 ];

--- a/site/src/utils/constants.js
+++ b/site/src/utils/constants.js
@@ -181,7 +181,7 @@ export const accountExtinsicsHead = blockExtrinsicsHead;
 
 export const assetsHead = [
   { name: "Asset ID", width: 160 },
-  { name: "Symbol", width: 224 },
+  { name: "Symbol", width: 232 },
   { name: "Owner", width: 200 },
   { name: "Issuer", width: 200 },
   { name: "Holders", width: 160, align: "right" },


### PR DESCRIPTION
#348 
close #354 

- [x] home page assets
- [x] table
   - [x] no `price` column
   - [x] symbol icon
   - [x] symbol name

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/19513289/210320562-dabddd2a-dcc2-45ef-99cb-cac198b6aacb.png">
