### PR TITLE
feat: header menu dropdown support types, group, divider

### DIFF
--- a/site/src/components/header/index.js
+++ b/site/src/components/header/index.js
@@ -130,19 +130,11 @@ export default function Header() {
                 <MenuItem>Home</MenuItem>
               </Link>
               <MenuItem>
-                <SubMenu
-                  category="BlockChain"
-                  menus={menusBlockchain}
-                  divideIndex={4}
-                />
+                <SubMenu category="BlockChain" menus={menusBlockchain} />
               </MenuItem>
               {assets && (
                 <MenuItem>
-                  <SubMenu
-                    category="Assets"
-                    menus={menusAssets}
-                    divideIndex={4}
-                  />
+                  <SubMenu category="Assets" menus={menusAssets} />
                 </MenuItem>
               )}
             </MenuWrapper>

--- a/site/src/components/header/subMenu.js
+++ b/site/src/components/header/subMenu.js
@@ -114,8 +114,8 @@ function SubMenuItems({ item, closeMenu, setIsActive }) {
     return (
       <SubMenuGroup>
         <SubMenuGroupTitle>{item.name}</SubMenuGroupTitle>
-        {item.menus.map((subItem, subIdx) => (
-          <SubMenuItems key={subIdx} item={subItem} />
+        {item.menus.map((subMenuItem, subIdx) => (
+          <SubMenuItems key={subIdx} item={subMenuItem} />
         ))}
       </SubMenuGroup>
     );
@@ -157,10 +157,10 @@ export default function SubMenu({ category, menus, closeMenu }) {
       {isActive && (
         <MouseWrapper>
           <MenuWrapper ref={ref}>
-            {menus.map((item, idx) => (
+            {menus.map((menuItem, idx) => (
               <SubMenuItems
                 key={idx}
-                item={item}
+                item={menuItem}
                 closeMenu={closeMenu}
                 setIsActive={setIsActive}
               />

--- a/site/src/components/header/subMenu.js
+++ b/site/src/components/header/subMenu.js
@@ -1,5 +1,5 @@
 import { useState, useRef, Fragment } from "react";
-import { Inter_14_500 } from "../../styles/text";
+import { Inter_12_600, Inter_14_500 } from "../../styles/text";
 import styled, { css } from "styled-components";
 import { Panel } from "../styled/panel";
 import Link from "../styled/link";
@@ -93,12 +93,50 @@ const MenuItem = styled.div`
     `}
 `;
 
-export default function SubMenu({
-  category,
-  menus,
-  closeMenu,
-  divideIndex = 2,
-}) {
+const SubMenuGroupTitle = styled.div`
+  color: ${(p) => p.theme.fontTertiary};
+  padding: 8px 12px;
+  text-transform: uppercase;
+  ${Inter_12_600};
+`;
+const SubMenuGroup = styled.div`
+  ${MenuItem} {
+    padding-left: 24px;
+  }
+`;
+
+function SubMenuItems({ item, closeMenu, setIsActive }) {
+  if (item.type === "divider") {
+    return <Divider />;
+  }
+
+  if (item.type === "group") {
+    return (
+      <SubMenuGroup>
+        <SubMenuGroupTitle>{item.name}</SubMenuGroupTitle>
+        {item.menus.map((subItem, subIdx) => (
+          <SubMenuItems key={subIdx} item={subItem} />
+        ))}
+      </SubMenuGroup>
+    );
+  }
+
+  return (
+    <Link to={`/${item.value}`}>
+      <MenuItem
+        onClick={() => {
+          closeMenu && closeMenu();
+          setIsActive(false);
+        }}
+        disabled={item.value === ""}
+      >
+        {item.name}
+      </MenuItem>
+    </Link>
+  );
+}
+
+export default function SubMenu({ category, menus, closeMenu }) {
   const [isActive, setIsActive] = useState(false);
   const ref = useRef();
 
@@ -119,24 +157,14 @@ export default function SubMenu({
       {isActive && (
         <MouseWrapper>
           <MenuWrapper ref={ref}>
-            {menus.map((item, index) => {
-              return (
-                <Fragment key={index}>
-                  {index === divideIndex && <Divider />}
-                  <Link to={`/${item.value}`}>
-                    <MenuItem
-                      onClick={() => {
-                        closeMenu && closeMenu();
-                        setIsActive(false);
-                      }}
-                      disabled={item.value === ""}
-                    >
-                      {item.name}
-                    </MenuItem>
-                  </Link>
-                </Fragment>
-              );
-            })}
+            {menus.map((item, idx) => (
+              <SubMenuItems
+                key={idx}
+                item={item}
+                closeMenu={closeMenu}
+                setIsActive={setIsActive}
+              />
+            ))}
           </MenuWrapper>
         </MouseWrapper>
       )}

--- a/site/src/utils/constants.js
+++ b/site/src/utils/constants.js
@@ -30,6 +30,9 @@ export const menusBlockchain = [
     value: "calls",
   },
   {
+    type: "divider",
+  },
+  {
     name: "Transfers",
     value: "transfers",
   },


### PR DESCRIPTION
<img width="177" alt="image" src="https://user-images.githubusercontent.com/19513289/212003055-dd2c435e-c56e-4734-bd2b-81ac3e10a836.png">

```js
export const menusAssets = [
  {
    name: "NFT",
    value: "nfts",
  },
  {
    type: "divider",
  },
  {
    type: "group",
    name: "Destroyed",
    menus: [
      {
        name: "Assets",
        value: "destroyed/assets",
      },
    ],
  },
];

```