### PR TITLE
Some patches on React App & added from filter to transfer list API

### DIFF
--- a/backend/packages/server/src/features/accounts/controllers/transfers.js
+++ b/backend/packages/server/src/features/accounts/controllers/transfers.js
@@ -15,6 +15,9 @@ async function getAccountTransfers(ctx) {
   const q = {
     $or: [{ from: address }, { to: address }],
   };
+  if (ctx.query.from) {
+    q["$and"] = [{ from: ctx.query.from }];
+  }
   const col = await getTransferCollection();
   const items = await col
     .find(q, { projection: { _id: 0 } })

--- a/site/.env.example
+++ b/site/.env.example
@@ -7,3 +7,6 @@ REACT_APP_PUBLIC_CHAIN=polkadot
 REACT_APP_DEFAULT_IPFS_GATEWAY=https://cloudflare-ipfs.com/ipfs/
 
 REACT_APP_PUBLIC_SIMPLE_MODE=true
+
+# Optional, if you want to use browser router instead hash router.
+#REACT_APP_BROWSER_ROUTER=1

--- a/site/src/App.js
+++ b/site/src/App.js
@@ -1,4 +1,4 @@
-import { HashRouter, Route, Routes } from "react-router-dom";
+import { HashRouter, BrowserRouter, Route, Routes } from "react-router-dom";
 import Extrinsics from "./pages/extrinsics";
 import Blocks from "./pages/blocks";
 import Home from "./pages";
@@ -30,13 +30,15 @@ import OnChainAccount from "./pages/onChainAccount";
 import OnChainExtrinsic from "./pages/onChainExtrinsic";
 import OnChainEvent from "./pages/onChainEvent";
 
+const Router = process.env.REACT_APP_BROWSER_ROUTER ? BrowserRouter : HashRouter
+
 function App() {
   const { assets, uniques, identity } = getChainModules();
   const isUseOnChainBlockData = getIsUseOnChainBlockData();
   useSubFinalizedHeight();
 
   return (
-    <HashRouter>
+    <Router>
       <Routes>
         {assets && (
           <Fragment>
@@ -89,7 +91,7 @@ function App() {
           </>
         )}
       </Routes>
-    </HashRouter>
+    </Router>
   );
 }
 

--- a/site/src/components/home/explore/utils.js
+++ b/site/src/components/home/explore/utils.js
@@ -23,5 +23,9 @@ export function makeExploreDropdownItemRouteLink(type, value) {
     return `/accounts/${value}`;
   }
 
+  if (type === 'extrinsic') {
+    return `/extrinsics/${value}`;
+  }
+
   return `/${type}/${value}`;
 }

--- a/site/src/services/chainApi.js
+++ b/site/src/services/chainApi.js
@@ -3,13 +3,47 @@ import { getChainNodes } from "../utils/chain";
 
 const apiInstanceMap = new Map();
 
+function createPromise(url) {
+  let instance = null
+  return async function () {
+    if (instance) {
+      return instance
+    }
+    const http = url.replace('wss://', 'https://').replace('ws://', 'http://')
+    const [blockHashResp, specResp] = await Promise.all([
+      fetch(http, { method: 'POST', body: '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}', headers: { 'content-type': 'application/json' } }).then(resp => resp.json()),
+      fetch(http, { method: 'POST', body: '{"id":2,"jsonrpc":"2.0","method":"state_getRuntimeVersion","params":[]}', headers: { 'content-type': 'application/json' } }).then(resp => resp.json()),
+    ])
+    const id = `${blockHashResp.result}-${specResp.result.specVersion}`
+    let metadata = localStorage.getItem(id)
+    if (!metadata) {
+      const metadataResp = await fetch(
+        http,
+        {
+          method: 'POST',
+          body: '{"id":3,"jsonrpc":"2.0","method":"state_getMetadata","params":[]}',
+          headers: { 'content-type': 'application/json' }
+        }
+      ).then(resp => resp.json())
+      metadata = metadataResp.result
+      localStorage.setItem(id, metadata)
+    }
+    instance = await ApiPromise.create({
+      provider: new WsProvider(url),
+      noInitWarn: true,
+      metadata: { [id]: metadata },
+    })
+    return instance
+  }()
+}
+
 export function getChainApi(queryUrl) {
   const nodes = getChainNodes();
   const url = queryUrl || nodes[0]?.url;
   if (!apiInstanceMap.has(url)) {
     apiInstanceMap.set(
       url,
-      ApiPromise.create({ provider: new WsProvider(url) }),
+      createPromise(url)
     );
   }
   return apiInstanceMap.get(url);


### PR DESCRIPTION
This PR proposes follow-up changes from the Phala Team, which may include nice-to-have patches and bug fixes.

1. We have added a `from` filter to the transfer list API. This filter is useful when calling the API `/accounts/[address]/transfer` directly, as it allows us to filter out transaction records from a specified address.
2. The broken link in the explorer dropdown has been fixed. Previously, when searching for a transaction ID, it did not navigate to the correct extrinsic detail page.
3. To improve RPC initialization time, we have implemented metadata caching in the browser's localStorage. In our experience, there were instances where substrate RPC would get stuck on fetching metadata. Since the metadata size is large and cacheable, this improvement helps achieve a more stable initialization time.
4. We have introduced an environment variable called `REACT_APP_BROWSER_ROUTER`. This variable can be used to switch from the default HashRouter to BrowserRouter if needed. It does not change the default behavior and serves as a progressive enhancement option.