### PR TITLE
fix(constants): correct assetsMenuItem value path

### DIFF
--- a/site/src/utils/constants.js
+++ b/site/src/utils/constants.js
@@ -75,7 +75,7 @@ export const menusAssetsDestroyed = [
 
 export const assetsMenuItem = {
   name: "Assets",
-  value: "destroyed/assets",
+  value: "assets",
 };
 
 export const dividerMenuItem = {


### PR DESCRIPTION
Mobile version menu of the 'Assets' leads to the destroyed assets instead of the assets list