### PR TITLE
Index Bulletin storage extrinsics, strip store payload args

### DIFF
--- a/backend/packages/block-scan/src/scan/common/consts.js
+++ b/backend/packages/block-scan/src/scan/common/consts.js
@@ -23,6 +23,14 @@ const commonNecessarySections = [
   "fellowshipTreasury",
 ];
 
+// Bulletin store extrinsic args carry the full data payload (up to 2MB),
+// so clean extrinsic args but keep transactionStorage events, which only
+// carry the CID/content hash.
+const necessaryEventSections = [
+  ...commonNecessarySections,
+  "transactionStorage",
+];
+
 const chainsNeedToClean = [
   "westend",
   "paseo",
@@ -34,12 +42,14 @@ const chainsNeedToClean = [
   "nexus",
   "datahaven-testnet",
   "argon",
+  "bulletin-polkadot",
 ];
 
 const chainsNoNeedCalls = [...chainsNeedToClean, "bridgehub-westend"];
 
 module.exports = {
   commonNecessarySections,
+  necessaryEventSections,
   chainsNeedToClean,
   chainsNoNeedCalls,
 };

--- a/backend/packages/block-scan/src/scan/event/clean/index.js
+++ b/backend/packages/block-scan/src/scan/event/clean/index.js
@@ -2,14 +2,14 @@ const {
   env: { currentChain },
 } = require("@osn/scan-common");
 const {
-  commonNecessarySections,
+  necessaryEventSections,
   chainsNeedToClean,
 } = require("../../common/consts");
 
 function getEventWithCleanedArgs(normalizedEvent) {
   const { section } = normalizedEvent || {};
   if (
-    commonNecessarySections.includes(section) ||
+    necessaryEventSections.includes(section) ||
     !chainsNeedToClean.includes(currentChain())
   ) {
     return normalizedEvent;

--- a/backend/packages/block-scan/src/scan/extrinsic/index.js
+++ b/backend/packages/block-scan/src/scan/extrinsic/index.js
@@ -33,6 +33,7 @@ async function normalizeExtrinsics(
         "nexus",
         "cere",
         "argon",
+        "bulletin-polkadot",
       ].includes(chain)
     ) {
       continue;


### PR DESCRIPTION
refs #1181

Two gaps for `bulletin-polkadot` ahead of storage traffic arriving on the chain:

- `transactionStorage.store` calls can be unsigned (preimage-authorized), so add the chain to the unsigned indexing allowlist.
- Store call args carry the full data payload (up to 2 MiB per call, blocks up to 10 MiB), so add the chain to `chainsNeedToClean` to strip extrinsic args. transactionStorage events are kept via an event-only whitelist: they carry just the CID/content hash, which is what the explorer should display. No behavior change for other chains, none of them has a `transactionStorage` section.